### PR TITLE
Updated GroupDocs.Viewer to 21.12

### DIFF
--- a/GroupDocs.Viewer.Cli.Common/GroupDocs.Viewer.Cli.Common.csproj
+++ b/GroupDocs.Viewer.Cli.Common/GroupDocs.Viewer.Cli.Common.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GroupDocs.Viewer" Version="21.11.0" />
+    <PackageReference Include="GroupDocs.Viewer" Version="21.12.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.80.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GroupDocs.Viewer.Cli.Tests.Docker/GroupDocs.Viewer.Cli.Tests.Docker.csproj
+++ b/GroupDocs.Viewer.Cli.Tests.Docker/GroupDocs.Viewer.Cli.Tests.Docker.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.80.2" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.80.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GroupDocs.Viewer.Cli/GroupDocs.Viewer.Cli.csproj
+++ b/GroupDocs.Viewer.Cli/GroupDocs.Viewer.Cli.csproj
@@ -36,7 +36,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GroupDocs.Viewer" Version="21.11.0" />
+		<PackageReference Include="GroupDocs.Viewer" Version="21.12.0" />
+		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.80.3" />
 	</ItemGroup>
 
         <ItemGroup>


### PR DESCRIPTION
GroupDocs.Viewer 21.12 release notes: https://docs.groupdocs.com/viewer/net/groupdocs-viewer-for-net-21-12-release-notes/