### PR TITLE
Updated GroupDocs.Viewer to 22.11.

### DIFF
--- a/src/GroupDocs.Viewer.Cli.Common/GroupDocs.Viewer.Cli.Common.csproj
+++ b/src/GroupDocs.Viewer.Cli.Common/GroupDocs.Viewer.Cli.Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GroupDocs.Viewer" Version="22.9.0" />
+    <PackageReference Include="GroupDocs.Viewer" Version="22.11.0" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.80.3" />
   </ItemGroup>
 

--- a/src/GroupDocs.Viewer.Cli/GroupDocs.Viewer.Cli.csproj
+++ b/src/GroupDocs.Viewer.Cli/GroupDocs.Viewer.Cli.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="GroupDocs.Viewer" Version="22.9.0" />
+		<PackageReference Include="GroupDocs.Viewer" Version="22.11.0" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.80.3" />
 	</ItemGroup>
 


### PR DESCRIPTION
Updated GroupDocs.Viewer to 22.11. Release notes https://docs.groupdocs.com/viewer/net/groupdocs-viewer-for-net-22-11-release-notes/